### PR TITLE
feat: Switch to all-in-one as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ make build-images
 make stack-up
 ```
 
+This starts the application in **all-in-one mode** (default):
+- Single manager service with embedded workers
+- MySQL database for storage
+- Minio for blob storage
+- Workers communicate via in-memory channels queue
+
+For distributed mode (separate worker services), see the distributed configuration examples in `cmd/slides-to-video-manager/configuration/`.
+
 To test that all endpoints is working:
 
 ```bash

--- a/cmd/slides-to-video-manager/config.go
+++ b/cmd/slides-to-video-manager/config.go
@@ -155,6 +155,18 @@ func envVarOrDefaultInt(envVar string, defaultVal int) int {
 	return defaultVal
 }
 
+func envVarOrDefaultBool(envVar string, defaultVal bool) bool {
+	overrideVal, exists := os.LookupEnv(envVar)
+	if exists {
+		b, err := strconv.ParseBool(overrideVal)
+		if err != nil {
+			return defaultVal
+		}
+		return b
+	}
+	return defaultVal
+}
+
 func ConfigStructLevelValidation(sl validator.StructLevel) {
 	cfg := sl.Current().Interface().(config)
 

--- a/cmd/slides-to-video-manager/configuration/config.yaml
+++ b/cmd/slides-to-video-manager/configuration/config.yaml
@@ -1,3 +1,7 @@
+# Default all-in-one mode configuration
+# Note: Most of these values match the hardcoded defaults in root.go
+# This file is provided as a reference and for overriding specific values
+
 server:
   host: "0.0.0.0"
   port: 8080
@@ -11,8 +15,20 @@ server:
   authSecret: ""
   issuer: ""
   expiryTime: 3600
+
+# Embedded workers configuration (all-in-one mode)
 workers:
-  enabled: false
+  enabled: true
+  pdfSplitter:
+    enabled: true
+    concurrency: 1
+  imageToVideo:
+    enabled: true
+    concurrency: 2
+  concatenateVideo:
+    enabled: true
+    concurrency: 1
+
 datastore:
   type: "mysql"
   mysql:
@@ -21,13 +37,16 @@ datastore:
     host: "db"
     port: 3306
     dbName: "some-database"
+
+# Channels queue for in-memory communication (all-in-one mode)
 queue:
-  type: "nats"
-  nats:
-    endpoint: "nats://queue:4222"
+  type: "channels"
+  channels:
+    bufferSize: 100
     pdfToImageTopic: "pdf-splitter"
     imageToVideoTopic: "image-to-video"
     videoConcatTopic: "concatenate-video"
+
 blobStorage:
   type: "minio"
   minio:

--- a/cmd/slides-to-video-manager/root.go
+++ b/cmd/slides-to-video-manager/root.go
@@ -15,9 +15,9 @@ var (
 	cfgFile string
 
 	// Includes default configuration
-	// Initial configuration is set to utilize Google Datastore and Google Pubsub for now
+	// Default configuration is set for all-in-one mode with embedded workers
+	// Uses MySQL for datastore, Minio for storage, and channels queue for embedded workers
 	// Immediately replaces value with environment variables on startup
-	// TODO: Utilize Inmemory queue and inmemory datastores in the future
 	cfg = config{
 		Server: serverConfig{
 			Host:           envVarOrDefault("SERVER_HOST", "0.0.0.0"),
@@ -31,8 +31,23 @@ var (
 			AuthIssuer:     envVarOrDefault("SERVER_AUTHISSUER", "issuer"),
 			AuthExpiryTime: envVarOrDefaultInt("SERVER_AUTHEXPIRYTIME", 3600),
 		},
+		Workers: workersConfig{
+			Enabled: envVarOrDefaultBool("WORKERS_ENABLED", true),
+			PDFSplitter: workerInstanceConfig{
+				Enabled:     envVarOrDefaultBool("WORKERS_PDFSPLITTER_ENABLED", true),
+				Concurrency: envVarOrDefaultInt("WORKERS_PDFSPLITTER_CONCURRENCY", 1),
+			},
+			ImageToVideo: workerInstanceConfig{
+				Enabled:     envVarOrDefaultBool("WORKERS_IMAGETOVIDEO_ENABLED", true),
+				Concurrency: envVarOrDefaultInt("WORKERS_IMAGETOVIDEO_CONCURRENCY", 2),
+			},
+			ConcatenateVideo: workerInstanceConfig{
+				Enabled:     envVarOrDefaultBool("WORKERS_CONCATENATEVIDEO_ENABLED", true),
+				Concurrency: envVarOrDefaultInt("WORKERS_CONCATENATEVIDEO_CONCURRENCY", 1),
+			},
+		},
 		Datastore: datastoreConfig{
-			Type: envVarOrDefault("DATASTORE_TYPE", "google_datastore"),
+			Type: envVarOrDefault("DATASTORE_TYPE", "mysql"),
 			GoogleDatastoreConfig: &googleDatastoreConfig{
 				ProjectID:              envVarOrDefault("DATASTORE_GOOGLEDATASTORE_PROJECTID", ""),
 				UserTableName:          envVarOrDefault("DATASTORE_GOOGLEDATASTORE_USERTABLENAME", "UserTable"),
@@ -43,33 +58,42 @@ var (
 			MySQLConfig: &mysqlConfig{
 				User:     envVarOrDefault("DATASTORE_MYSQL_USER", "user"),
 				Password: envVarOrDefault("DATASTORE_MYSQL_PASSWORD", "password"),
-				Host:     envVarOrDefault("DATASTORE_MYSQL_HOST", "mysql"),
+				Host:     envVarOrDefault("DATASTORE_MYSQL_HOST", "db"),
 				Port:     envVarOrDefaultInt("DATASTORE_MYSQL_PORT", 3306),
-				DBName:   envVarOrDefault("DATASTORE_MYSQL_DBNAME", "slides_to_video_mgr"),
+				DBName:   envVarOrDefault("DATASTORE_MYSQL_DBNAME", "some-database"),
 			},
 		},
 		Queue: queueConfig{
-			Type: envVarOrDefault("QUEUE_TYPE", "google_pubsub"),
+			Type: envVarOrDefault("QUEUE_TYPE", "channels"),
 			GooglePubsub: googlePubsubConfig{
 				ProjectID:         envVarOrDefault("QUEUE_GOOGLEPUBSUB_PROJECTID", ""),
 				PDFToImageTopic:   envVarOrDefault("QUEUE_GOOGLEPUBSUB_PDFTOIMAGEJOBTOPIC", "pdf-splitter"),
 				ImageToVideoTopic: envVarOrDefault("QUEUE_GOOGLEPUBSUB_IMAGETOVIDEOTOPIC", "image-to-video"),
 				VideoConcatTopic:  envVarOrDefault("QUEUE_GOOGLEPUBSUB_VIDEOCONCATTOPIC", "concatenate-video"),
 			},
+			Channels: channelsConfig{
+				BufferSize:        envVarOrDefaultInt("QUEUE_CHANNELS_BUFFERSIZE", 100),
+				PDFToImageTopic:   envVarOrDefault("QUEUE_CHANNELS_PDFTOIMAGETOPIC", "pdf-splitter"),
+				ImageToVideoTopic: envVarOrDefault("QUEUE_CHANNELS_IMAGETOVIDEOTOPIC", "image-to-video"),
+				VideoConcatTopic:  envVarOrDefault("QUEUE_CHANNELS_VIDEOCONCATTOPIC", "concatenate-video"),
+			},
 		},
 		BlobStorage: blobConfig{
-			Type: envVarOrDefault("BLOBSTORAGE_TYPE", "gcs"),
+			Type: envVarOrDefault("BLOBSTORAGE_TYPE", "minio"),
 			GCS: gcsConfig{
 				ProjectID: envVarOrDefault("BLOBSTORAGE_GCS_PROJECTID", ""),
 				Bucket:    envVarOrDefault("BLOBSTORAGE_GCS_BUCKET", ""),
 				PDFFolder: envVarOrDefault("BLOBSTORAGE_GCS_PDFFOLDER", "pdf"),
 			},
 			Minio: minioConfig{
-				Bucket:          envVarOrDefault("BLOBSTORAGE_MINIO_BUCKET", ""),
-				Endpoint:        envVarOrDefault("BLOBSTORAGE_MINIO_ENDPOINT", ""),
-				AccessKeyID:     envVarOrDefault("BLOBSTORAGE_MINIO_ACCESSKEYID", ""),
-				SecretAccessKey: envVarOrDefault("BLOBSTORAGE_MINIO_SECRETACCESSKEY", ""),
-				PDFFolder:       envVarOrDefault("BLOBSTORAGE_MINIO_PDFFOLDER", "pdf"),
+				Bucket:              envVarOrDefault("BLOBSTORAGE_MINIO_BUCKET", "videos"),
+				Endpoint:            envVarOrDefault("BLOBSTORAGE_MINIO_ENDPOINT", "s3:9000"),
+				AccessKeyID:         envVarOrDefault("BLOBSTORAGE_MINIO_ACCESSKEYID", "s3_user"),
+				SecretAccessKey:     envVarOrDefault("BLOBSTORAGE_MINIO_SECRETACCESSKEY", "s3_password"),
+				PDFFolder:           envVarOrDefault("BLOBSTORAGE_MINIO_PDFFOLDER", "pdf"),
+				ImagesFolder:        envVarOrDefault("BLOBSTORAGE_MINIO_IMAGESFOLDER", "images"),
+				VideoSnippetsFolder: envVarOrDefault("BLOBSTORAGE_MINIO_VIDEOSNIPPETSFOLDER", "video-snippets"),
+				VideoFolder:         envVarOrDefault("BLOBSTORAGE_MINIO_VIDEOFOLDER", "videos"),
 			},
 		},
 	}

--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -10,8 +10,10 @@ services:
     ports:
       - 8880:8080
     depends_on:
-      - db
-      - s3
+      db:
+        condition: service_healthy
+      s3:
+        condition: service_healthy
     secrets:
       - manager_secrets.yaml
     command:
@@ -23,7 +25,8 @@ services:
   migrate:
     image: slides-to-video-manager
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     command:
       - "app"
       - "migrate"
@@ -37,6 +40,12 @@ services:
       MYSQL_DATABASE: some-database
       MYSQL_USER: user
       MYSQL_PASSWORD: password
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-proot"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
   s3:
     image: minio/minio:RELEASE.2020-11-19T23-48-16Z
     ports:
@@ -47,10 +56,17 @@ services:
     command:
       - "server"
       - "/data"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
   createbuckets:
     image: minio/mc:RELEASE.2020-11-17T00-39-14Z
     depends_on:
-      - s3
+      s3:
+        condition: service_healthy
     entrypoint: >
       /bin/sh -c "
       /usr/bin/mc config host add minio http://s3:9000 s3_user s3_password;

--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -9,63 +9,24 @@ services:
     image: slides-to-video-manager
     ports:
       - 8880:8080
-    volumes:
-      - ../../cmd/slides-to-video-manager/configuration:/root/configuration
+    depends_on:
+      - db
+      - s3
     secrets:
       - manager_secrets.yaml
     command:
       - "app"
       - "server"
       - "-c"
-      - "/root/configuration/config.yaml,/run/secrets/manager_secrets.yaml"
+      - "/run/secrets/manager_secrets.yaml"
     restart: always
-  pdfsplitter:
-    image: pdf-splitter
-    ports:
-      - 8881:8081
-    volumes:
-      - ../../cmd/pdf-splitter/configuration:/root/configuration
-    command:
-      - "app"
-      - "server"
-      - "-c"
-      - "/root/configuration/config.yaml"
-    restart: on-failure
   migrate:
     image: slides-to-video-manager
-    volumes:
-      - ../../cmd/slides-to-video-manager/configuration:/root/configuration
+    depends_on:
+      - db
     command:
       - "app"
       - "migrate"
-      - "-c"
-      - "/root/configuration/config.yaml"
-    restart: on-failure
-  image2video:
-    image: image-to-video
-    ports:
-      - 8882:8082
-    volumes:
-      - ../../cmd/image-to-video/configuration:/root/configuration
-    secrets:
-      - image_to_video_cred
-    command:
-      - "app"
-      - "server"
-      - "-c"
-      - "/root/configuration/config.yaml"
-    restart: on-failure
-  concatenatevideo:
-    image: concatenate-video
-    ports:
-      - 8883:8083
-    volumes:
-      - ../../cmd/concatenate-video/configuration:/root/configuration
-    command:
-      - "app"
-      - "server"
-      - "-c"
-      - "/root/configuration/config.yaml"
     restart: on-failure
   db:
     image: mysql:5.7
@@ -99,13 +60,8 @@ services:
       exit 0;
       "
     restart: on-failure
-  queue:
-    image: nats:2.1.9
 
 secrets:
-  image_to_video_cred:
-    file: image-to-video.json
   manager_secrets.yaml:
     file: manager_secrets.yaml
 
-    

--- a/deployment/helm/slides-to-video/values.yaml
+++ b/deployment/helm/slides-to-video/values.yaml
@@ -78,6 +78,17 @@ manager:
       authSecret: ""
       issuer: ""
       expiryTime: 3600
+    workers:
+      enabled: true
+      pdfSplitter:
+        enabled: true
+        concurrency: 1
+      imageToVideo:
+        enabled: true
+        concurrency: 2
+      concatenateVideo:
+        enabled: true
+        concurrency: 1
     datastore:
       type: "mysql"
       mysql:
@@ -87,9 +98,9 @@ manager:
         port: 3306
         dbName: "some-database"
     queue:
-      type: "nats"
-      nats:
-        endpoint: "nats://nats.default.svc:4222"
+      type: "channels"
+      channels:
+        bufferSize: 100
         pdfToImageTopic: "pdf-splitter"
         imageToVideoTopic: "image-to-video"
         videoConcatTopic: "concatenate-video"
@@ -98,6 +109,9 @@ manager:
       minio:
         bucket: "videos"
         pdfFolder: "pdf"
+        imagesFolder: "images"
+        videoSnippetsFolder: "video-snippets"
+        videoFolder: "videos"
         endpoint: "minio1-hl.default.svc.cluster.local:9000"
         accessKeyId: "minio"
         secretAccessKey: "minio123"

--- a/docs/SERVICE-CONSOLIDATION.md
+++ b/docs/SERVICE-CONSOLIDATION.md
@@ -2,15 +2,21 @@
 
 ## Overview
 
-The slides-to-video application now supports two deployment architectures:
+The slides-to-video application supports two deployment architectures:
 
-1. **All-in-One Mode**: Single process with embedded workers using Go channels
+1. **All-in-One Mode (Default)**: Single process with embedded workers using Go channels
 2. **Distributed Mode**: Separate services communicating via NATS or Google Pub/Sub
 
-This provides flexibility for different deployment scenarios:
-- **Development**: All-in-one mode simplifies local development
-- **Small Deployments**: All-in-one mode reduces operational complexity
-- **Production**: Distributed mode enables horizontal scaling and fault isolation
+**All-in-one mode is the default and recommended configuration** for most deployments. It provides:
+- Simpler setup and operation
+- Lower resource overhead
+- Faster local development
+- Reduced operational complexity
+
+**Distributed mode** is available for specific production scenarios requiring:
+- Independent horizontal scaling of workers
+- Fault isolation between components
+- Multi-machine distributed processing
 
 ## What Changed
 
@@ -34,7 +40,7 @@ This provides flexibility for different deployment scenarios:
 
 ### Architecture Modes
 
-#### Mode 1: All-in-One (Channels Queue)
+#### Mode 1: All-in-One (Channels Queue) - DEFAULT
 
 ```text
 ┌─────────────────────────────────────────┐
@@ -59,7 +65,9 @@ This provides flexibility for different deployment scenarios:
   MySQL + Minio
 ```
 
-**Configuration:**
+**Configuration (Hardcoded Defaults):**
+
+The manager uses these defaults automatically - no configuration file required!
 ```yaml
 workers:
   enabled: true
@@ -82,23 +90,29 @@ queue:
     videoConcatTopic: "concatenate-video"
 ```
 
-**Use Cases:**
+**Use Cases (Recommended for Most Deployments):**
 - Local development
 - Single-server deployments
 - Cost-sensitive environments
 - Testing and CI/CD pipelines
+- Small to medium production workloads
+- Default deployment mode
 
 **Pros:**
 - Simple deployment (single binary)
 - No external queue infrastructure required
 - Lower latency (no network calls)
 - Lower resource usage
+- Easier to debug and monitor
+- Default configuration works out-of-the-box
 
 **Cons:**
 - Cannot scale workers independently
 - Manager crash affects all workers
 - No distributed processing
 - Limited by single machine resources
+
+**Note:** For most use cases, these limitations are not significant. Consider distributed mode only if you specifically need independent worker scaling or multi-machine distribution.
 
 #### Mode 2: Distributed (NATS/Pub/Sub)
 
@@ -130,11 +144,11 @@ queue:
     videoConcatTopic: "concatenate-video"
 ```
 
-**Use Cases:**
-- Production deployments
-- High-availability requirements
-- Need for horizontal scaling
-- Fault isolation between components
+**Use Cases (Advanced Deployments Only):**
+- Large-scale production deployments with high throughput
+- Specific need for independent worker horizontal scaling
+- Multi-machine distributed processing requirements
+- Strict fault isolation requirements between components
 
 **Pros:**
 - Scale workers independently
@@ -143,10 +157,13 @@ queue:
 - Distributed processing across machines
 
 **Cons:**
-- More complex deployment
+- More complex deployment and operations
 - Requires NATS/Pub/Sub infrastructure
 - Higher latency (network calls)
 - Higher resource usage
+- More complex debugging and monitoring
+
+**Recommendation:** Only use this mode if you have a specific requirement that all-in-one mode cannot satisfy.
 
 #### Mode 3: Hybrid
 
@@ -271,14 +288,24 @@ blobStorage:
 
 ## Running the Application
 
-### All-in-One Mode
+### All-in-One Mode (Default)
 
 ```bash
-# Build the manager
+# Build and start the stack
 make build-bin
+make build-images
+make stack-up
 
-# Run with all-in-one configuration
+# Or run manager directly (uses hardcoded defaults)
+./bin/slides-to-video-manager server
+
+# Optional: Override defaults with config file
 ./bin/slides-to-video-manager server -c cmd/slides-to-video-manager/configuration/config-all-in-one.yaml
+
+# Optional: Override with environment variables
+export WORKERS_ENABLED=true
+export QUEUE_TYPE=channels
+./bin/slides-to-video-manager server
 ```
 
 ### Distributed Mode


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * All-in-one mode enabled by default: manager runs embedded workers, MySQL datastore, MinIO object storage, and buffered in-memory channels for queues; per-worker concurrency configurable.

* **Refactor**
  * Simplified deployment: separate worker services consolidated into the manager; health checks added for DB and object storage; compose/helm defaults updated.

* **Documentation**
  * Deployment and running guides revised to call out All-in-One as default and document switching to Distributed mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->