### PR TITLE
refactor: Change to mariadb

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ The application consists of five main services (deployable together or separatel
    - Alternative **slides-to-video-frontend-alt**: Go-based template UI
 
 ### Supporting Infrastructure
-- **MySQL** (port 3306): Primary data store for local dev
+- **MariaDB 12.2.2** (port 3306): Primary data store for local dev
 - **Local File Storage** (/data/storage): Default blob storage for local dev (Docker volume)
 - **Minio** (port 9999): S3-compatible blob storage for local dev
 - **NATS** (port 4222): Message queue for distributed mode
@@ -110,7 +110,7 @@ The application consists of five main services (deployable together or separatel
 - **Google Cloud Storage**: Production blob storage (requires GCS credentials)
 
 ### Production Alternatives
-- Google Cloud Datastore replaces MySQL
+- Google Cloud Datastore replaces MariaDB
 - Google Cloud Storage replaces Local Storage or Minio
 - Google Pub/Sub replaces NATS
 - Channels queue for single-process deployments
@@ -161,7 +161,7 @@ Each worker service has its own package under cmd/:
 ### Storage Layer Pattern
 Each domain model package contains store interfaces and implementations:
 - `store.go`: Interface definition
-- `mysql.go`: MySQL implementation
+- `mysql.go`: MariaDB implementation
 - `datastore.go`: Google Cloud Datastore implementation
 - Tests use common test suites to verify both implementations
 
@@ -184,7 +184,7 @@ app server -c /path/to/config.yaml
 ```
 
 Configuration controls:
-- Storage backend selection (MySQL vs Datastore, Minio vs GCS)
+- Storage backend selection (MariaDB vs Datastore, Minio vs GCS)
 - Queue backend selection (NATS vs Pub/Sub)
 - Service URLs for inter-service communication
 - Credentials and secrets
@@ -193,7 +193,7 @@ Configuration controls:
 
 When adding new domain models:
 1. Create package with struct definition
-2. Implement Store interface with both MySQL and Datastore backends
+2. Implement Store interface with both MariaDB and Datastore backends
 3. Add handlers in handlers/ package
 4. Add routes in cmd/slides-to-video-manager/serve.go
 5. Add client methods in client/ package if workers need access
@@ -242,8 +242,8 @@ The tests/ directory contains pytest-based integration tests that:
 
 ### Unit Tests
 Go packages use testcontainers for database-dependent tests:
-- Spins up MySQL container for test isolation
-- Tests both MySQL and Datastore implementations
+- Spins up MariaDB container for test isolation
+- Tests both MariaDB and Datastore implementations
 - Located alongside source files (*_test.go)
 
 ### Test Requirements
@@ -258,7 +258,7 @@ Services communicate via service names, use local file storage (default) or Mini
 
 ### Kubernetes (Helm)
 Helm charts in deployment/helm/slides-to-video/ support:
-- StatefulSet for MySQL
+- StatefulSet for MariaDB
 - Deployments for each service
 - ConfigMaps for configuration
 - Secrets for credentials
@@ -275,7 +275,7 @@ Services deployed as independent Cloud Run services:
 - **Google Cloud Text-to-Speech API**: Required for audio narration in image-to-video worker
 - **gorilla/mux**: HTTP routing
 - **spf13/cobra**: CLI framework
-- **jinzhu/gorm**: ORM for MySQL
+- **jinzhu/gorm**: ORM for MariaDB
 - **cloud.google.com/go/datastore**: Google Datastore client
 - **minio-go**: Minio/S3 client
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ make stack-up
 
 This starts the application in **all-in-one mode** with:
 - Single manager service with embedded workers
-- MySQL database for storage
+- MariaDB 12.2.2 database for storage
 - Local file storage at `/data/storage`
 - Workers communicate via in-memory channels queue
 
@@ -57,7 +57,7 @@ make format
 
 - Introduce proper unit testing for all db related components
   - Need to ensure that records are pushed/pulled from storage accordingly
-  - Need to ensure for all object types that have both google cloud datastore and mysql
+  - Need to ensure for all object types that have both google cloud datastore and mariadb
 - Provide a user page with some details
   - Create dashboard on per user basis
   - Maximum no of projects available for user

--- a/acl/mysql_test.go
+++ b/acl/mysql_test.go
@@ -23,11 +23,11 @@ func databaseConnProvider(port int) *gorm.DB {
 
 func Test_mysql_ops(t *testing.T) {
 	// Following command is similar to this docker command:
-	// docker run --name some-mysql -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=test-database -e MYSQL_USER=user -e MYSQL_PASSWORD=password -d -p 3306:3306 mysql:5.7
+	// docker run --name some-mariadb -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=test-database -e MYSQL_USER=user -e MYSQL_PASSWORD=password -d -p 3306:3306 mariadb:12.2.2
 	req, _ := testcontainers.GenericContainer(context.TODO(), testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image: "mysql:5.7",
-			Name:  "some-mysql",
+			Image: "mariadb:12.2.2",
+			Name:  "some-mariadb",
 			Env: map[string]string{
 				"MYSQL_ROOT_PASSWORD": "root",
 				"MYSQL_DATABASE":      "test-database",

--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -37,7 +37,7 @@ services:
       - "/root/configuration/config.yaml"
     restart: on-failure
   db:
-    image: mysql:5.7
+    image: mariadb:12.2.2
     ports:
       - 3306:3306
     environment:

--- a/docs/SERVICE-CONSOLIDATION.md
+++ b/docs/SERVICE-CONSOLIDATION.md
@@ -62,7 +62,7 @@ The slides-to-video application supports two deployment architectures:
 └─────────────────────────────────────────┘
         │
         ▼
-  MySQL + Minio
+  MariaDB + Minio
 ```
 
 **Configuration (Hardcoded Defaults):**
@@ -314,7 +314,7 @@ export QUEUE_TYPE=channels
 # Build all binaries
 make build-bin
 
-# Start infrastructure (MySQL, Minio, NATS)
+# Start infrastructure (MariaDB, Minio, NATS)
 docker-compose -f docker-compose-infra.yaml up -d
 
 # Start manager

--- a/pdfslideimages/mysql_test.go
+++ b/pdfslideimages/mysql_test.go
@@ -22,11 +22,11 @@ func databaseConnProvider(port int) *gorm.DB {
 
 func Test_mysql_ops(t *testing.T) {
 	// Following command is similar to this docker command:
-	// docker run --name some-mysql -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=test-database -e MYSQL_USER=user -e MYSQL_PASSWORD=password -d -p 3306:3306 mysql:5.7
+	// docker run --name some-mariadb -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=test-database -e MYSQL_USER=user -e MYSQL_PASSWORD=password -d -p 3306:3306 mariadb:12.2.2
 	req, err := testcontainers.GenericContainer(context.TODO(), testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image: "mysql:5.7",
-			Name:  "some-mysql",
+			Image: "mariadb:12.2.2",
+			Name:  "some-mariadb",
 			Env: map[string]string{
 				"MYSQL_ROOT_PASSWORD": "root",
 				"MYSQL_DATABASE":      "test-database",

--- a/project/mysql_test.go
+++ b/project/mysql_test.go
@@ -27,11 +27,11 @@ func databaseConnProvider(port int) *gorm.DB {
 
 func Test_mysql_ops(t *testing.T) {
 	// Following command is similar to this docker command:
-	// docker run --name some-mysql -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=test-database -e MYSQL_USER=user -e MYSQL_PASSWORD=password -d -p 3306:3306 mysql:5.7
+	// docker run --name some-mariadb -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=test-database -e MYSQL_USER=user -e MYSQL_PASSWORD=password -d -p 3306:3306 mariadb:12.2.2
 	req, _ := testcontainers.GenericContainer(context.TODO(), testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image: "mysql:5.7",
-			Name:  "some-mysql",
+			Image: "mariadb:12.2.2",
+			Name:  "some-mariadb",
 			Env: map[string]string{
 				"MYSQL_ROOT_PASSWORD": "root",
 				"MYSQL_DATABASE":      "test-database",

--- a/queue/nats_test.go
+++ b/queue/nats_test.go
@@ -12,7 +12,7 @@ import (
 
 func Test_nats_ops(t *testing.T) {
 	// Following command is similar to this docker command:
-	// docker run --name some-mysql -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=test-database -e MYSQL_USER=user -e MYSQL_PASSWORD=password -d -p 3306:3306 mysql:5.7
+	// docker run --name some-nats -d -p 4222:4222 nats:2.1.9
 	req, err := testcontainers.GenericContainer(context.TODO(), testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
 			Image:        "nats:2.1.9",

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,7 +6,7 @@ The tests will need to target and run tests across the variety of platforms belo
 
 - "Local" setup with docker-compose. This would be priority 0 - meant for use for local development
   - Storage: Minio
-  - DB: MySQL
+  - DB: MariaDB 12.2.2
   - Queue: Nats
 - Google Serverless Platform. Cloud Run
   - Storage: GCS
@@ -14,7 +14,7 @@ The tests will need to target and run tests across the variety of platforms belo
   - Queue: Google Pubsub
 - Kubernetes
   - Storage: Minio, GCS
-  - DB: MySQL, Postgreql, Cloud SQL, Datastore, Cassandra
+  - DB: MariaDB, Postgreql, Cloud SQL, Datastore, Cassandra
   - Queue: Nats, Google Pubsub, RabbitMQ, Kafka
 
 Types of test to be run:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all references to use MariaDB 12.2.2 as the primary database across deployment and testing documentation.

* **Tests**
  * Updated test infrastructure and containers to use MariaDB 12.2.2 instead of MySQL 5.7.

* **Chores**
  * Updated Docker Compose and Kubernetes configurations to reference MariaDB as the data storage service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->